### PR TITLE
Expose `nixpkgs`

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -26,7 +26,6 @@ common:
       overlays = [
         (self: super: {
           arion = common.inputs.arion.packages.${system}.arion;
-          osrm-backend = common.inputs.nixpkgs-osrm.legacyPackages.${system}.osrm-backend;
         })
       ];
     };

--- a/flake.lock
+++ b/flake.lock
@@ -261,6 +261,21 @@
         "type": "github"
       }
     },
+    "nixpkgs-140774-workaround": {
+      "locked": {
+        "lastModified": 1678736468,
+        "narHash": "sha256-l5BdAeq9ymhUox0sTqeKibx9zkreWbIllwTvCamJLE8=",
+        "owner": "srid",
+        "repo": "nixpkgs-140774-workaround",
+        "rev": "335c2052970106d8f09f6f7f522f29d6ccaa2416",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "nixpkgs-140774-workaround",
+        "type": "github"
+      }
+    },
     "nixpkgs-21_11": {
       "locked": {
         "lastModified": 1659446231,
@@ -472,6 +487,7 @@
         "haskell-flake": "haskell-flake_2",
         "mission-control": "mission-control",
         "nixpkgs": "nixpkgs_4",
+        "nixpkgs-140774-workaround": "nixpkgs-140774-workaround",
         "nixpkgs-21_11": "nixpkgs-21_11",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
         "process-compose-flake": "process-compose-flake",

--- a/flake.lock
+++ b/flake.lock
@@ -261,21 +261,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-140774-workaround": {
-      "locked": {
-        "lastModified": 1677708284,
-        "narHash": "sha256-syAhlmvVlVDwgoKS6b3EfrQKfaeCY3zjT2q7VBk/yx8=",
-        "owner": "srid",
-        "repo": "nixpkgs-140774-workaround",
-        "rev": "5fe054e8560cf474b3c89622c1ea7688023425c1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "nixpkgs-140774-workaround",
-        "type": "github"
-      }
-    },
     "nixpkgs-21_11": {
       "locked": {
         "lastModified": 1659446231,
@@ -328,22 +313,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-osrm": {
-      "locked": {
-        "lastModified": 1681310105,
-        "narHash": "sha256-s76qhYeRHQXaaDd+9Qb4Frs6YXFPKZw7nudlZrRMh4E=",
-        "owner": "juspay",
-        "repo": "nixpkgs",
-        "rev": "62618152d22963c5b6ad3439b70049c4b01e1b98",
-        "type": "github"
-      },
-      "original": {
-        "owner": "juspay",
-        "ref": "osrm-backend",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1678872516,
@@ -392,6 +361,22 @@
     },
     "nixpkgs_4": {
       "locked": {
+        "lastModified": 1681358109,
+        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
         "lastModified": 1678898370,
         "narHash": "sha256-xTICr1j+uat5hk9FyuPOFGxpWHdJRibwZC+ATi0RbtE=",
         "owner": "NixOS",
@@ -406,7 +391,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1679944645,
         "narHash": "sha256-e5Qyoe11UZjVfgRfwNoSU57ZeKuEmjYb77B9IVW7L/M=",
@@ -446,7 +431,7 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils_2",
         "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_5",
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
@@ -486,9 +471,8 @@
         "flake-root": "flake-root",
         "haskell-flake": "haskell-flake_2",
         "mission-control": "mission-control",
-        "nixpkgs-140774-workaround": "nixpkgs-140774-workaround",
+        "nixpkgs": "nixpkgs_4",
         "nixpkgs-21_11": "nixpkgs-21_11",
-        "nixpkgs-osrm": "nixpkgs-osrm",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
         "process-compose-flake": "process-compose-flake",
         "treefmt-nix": "treefmt-nix"
@@ -520,7 +504,7 @@
     },
     "treefmt-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1680218481,

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,7 @@
     haskell-flake.url = "github:sbh69840/haskell-flake/poc-localapps";
     flake-root.url = "github:srid/flake-root";
     nixpkgs-21_11.url = "github:nixos/nixpkgs/nixos-21.11"; # Used for ormolu
+    nixpkgs-140774-workaround.url = "github:srid/nixpkgs-140774-workaround";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     cachix-push.url = "github:juspay/cachix-push";
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,13 @@
 {
   inputs = {
+    # nixpkgs is not used in 'common', it is shared with repos that use common.
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+
     flake-parts.url = "github:hercules-ci/flake-parts";
     # https://github.com/srid/haskell-flake/pull/137
     haskell-flake.url = "github:sbh69840/haskell-flake/poc-localapps";
     flake-root.url = "github:srid/flake-root";
     nixpkgs-21_11.url = "github:nixos/nixpkgs/nixos-21.11"; # Used for ormolu
-    nixpkgs-140774-workaround.url = "github:srid/nixpkgs-140774-workaround";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     cachix-push.url = "github:juspay/cachix-push";
 
@@ -15,8 +17,6 @@
     pre-commit-hooks-nix.url = "github:cachix/pre-commit-hooks.nix";
 
     # nixpkgs overrides
-    # https://github.com/NixOS/nixpkgs/pull/225008
-    nixpkgs-osrm.url = "github:juspay/nixpkgs/osrm-backend";
     # https://github.com/hercules-ci/arion/pull/192
     arion.url = "github:srid/arion/patch-1";
   };

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -5,9 +5,6 @@ common:
   _file = __curPos.file;
   perSystem = { pkgs, lib, config, ... }: {
     haskellProjects.default = {
-      imports = [
-        common.inputs.nixpkgs-140774-workaround.haskellFlakeProjectModules.default
-      ];
       basePackages = config.haskellProjects.ghc810.outputs.finalPackages;
       devShell = {
         tools = hp: {

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -16,7 +16,9 @@ common:
       # programs.hlint.enable = true;
       programs.ormolu.enable = true;
 
-      programs.ormolu.package = common.inputs.nixpkgs-21_11.legacyPackages.${system}.haskellPackages.ormolu;
+      programs.ormolu.package = 
+        let pkgs-21_11 = common.inputs.nixpkgs-21_11.legacyPackages.${system};
+        in common.inputs.nixpkgs-140774-workaround.patch pkgs-21_11 pkgs-21_11.haskellPackages.ormolu;
       settings.formatter.ormolu = {
         options = [
           "--ghc-opt"

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -16,9 +16,7 @@ common:
       # programs.hlint.enable = true;
       programs.ormolu.enable = true;
 
-      programs.ormolu.package =
-        let pkgs-21_11 = common.inputs.nixpkgs-21_11.legacyPackages.${system};
-        in common.inputs.nixpkgs-140774-workaround.patch pkgs-21_11 pkgs-21_11.haskellPackages.ormolu;
+      programs.ormolu.package = common.inputs.nixpkgs-21_11.legacyPackages.${system}.haskellPackages.ormolu;
       settings.formatter.ormolu = {
         options = [
           "--ghc-opt"


### PR DESCRIPTION
Use the latest nixpkgs (contains https://github.com/nammayatri/nammayatri/issues/425), and expose it for sharing with other repos.

- Remove the osrm overlay, because upstream PR merged
- Remove the darwin workaround import (no longer relevant for new nixpkgs), except for using it with old ormolu