### PR TITLE
Mobility GHC-9.2.7 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Nix-based project configuration shared between nammayatri repositories
 - Shared `nixpkgs` (used via [`follows`](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake#flake-inputs))
 - treefmt-based autoformatters: ormolu, hlint, dhall-format, nixpkgs-fmt
 - Common Haskell configuration
-  - GHC 8.10 package set (matching LTS 16.31 in part)
+  - ~~GHC 8.10 package set (matching LTS 16.31 in part)~~ (DEPRECATED, file and references kept for posterity only)
+  - GHC 9.2.7 package set
 - `mission-control`
 - `process-compose-flake`
 - pre-commit hooks

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -7,7 +7,8 @@ common:
     common.inputs.haskell-flake.flakeModule
     (import ./nix/treefmt.nix common)
     (import ./nix/haskell.nix common)
-    ./nix/ghc810.nix
+    # ./nix/ghc810.nix
+    ./nix/ghc927.nix
     ./nix/pre-commit.nix
     ./nix/arion.nix
     common.inputs.cachix-push.flakeModule

--- a/flake.lock
+++ b/flake.lock
@@ -119,11 +119,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1682984683,
-        "narHash": "sha256-fSMthG+tp60AHhNmaHc4StT3ltfHkQsJtN8GhfLWmtI=",
+        "lastModified": 1677714448,
+        "narHash": "sha256-Hq8qLs8xFu28aDjytfxjdC96bZ6pds21Yy09mSC156I=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "86684881e184f41aa322e653880e497b66429f3e",
+        "rev": "dc531e3a9ce757041e1afaff8ee932725ca60002",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
     },
     "flake-root": {
       "locked": {
-        "lastModified": 1680964220,
-        "narHash": "sha256-dIdTYcf+KW9a4pKHsEbddvLVSfR1yiAJynzg2x0nfWg=",
+        "lastModified": 1680210152,
+        "narHash": "sha256-VgFdqsu2i2oUcId9n8BFlRRc4GJHFvrmprdamcSZR1o=",
         "owner": "srid",
         "repo": "flake-root",
-        "rev": "f1c0b93d05bdbea6c011136ba1a135c80c5b326c",
+        "rev": "6000244701c8ae8cf43263564095fd357d89c328",
         "type": "github"
       },
       "original": {
@@ -224,11 +224,11 @@
     },
     "haskell-flake": {
       "locked": {
-        "lastModified": 1682714267,
-        "narHash": "sha256-DsGj9AIKqKcWQQOuwbFU77rkehaICzISHhH7aezZ6OQ=",
+        "lastModified": 1682614676,
+        "narHash": "sha256-Eu53z8fdtt8mfMRp+IskjclCT9LqvCViMOzvqO0Rz50=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "a904caac3e4638f84a28102762bf767dd1ae50c0",
+        "rev": "11ab35533afaf0cacc5f3ed8032cb2482cedf8fd",
         "type": "github"
       },
       "original": {
@@ -272,11 +272,11 @@
     },
     "mission-control": {
       "locked": {
-        "lastModified": 1682001320,
-        "narHash": "sha256-cXxEhjdJjWw1n8d14+PR8h/i0gLVLG2xq4kw5sJeuxg=",
+        "lastModified": 1680209746,
+        "narHash": "sha256-P8Q0mPdeo2SvKQUejvl7nOKO2ahIXb6aintYofCxcP8=",
         "owner": "Platonic-Systems",
         "repo": "mission-control",
-        "rev": "c2f3f0a8dce770c46bfa217270ee5592f3a5ebf5",
+        "rev": "c1bd7344283d4006efb02cc660c5fd9befb73980",
         "type": "github"
       },
       "original": {
@@ -329,11 +329,11 @@
     },
     "nixpkgs-140774-workaround": {
       "locked": {
-        "lastModified": 1681394207,
-        "narHash": "sha256-hk9RUPnChwKjCtm/YzixAak5wIzIw+b1avp7I3vg3dQ=",
+        "lastModified": 1678736468,
+        "narHash": "sha256-l5BdAeq9ymhUox0sTqeKibx9zkreWbIllwTvCamJLE8=",
         "owner": "srid",
         "repo": "nixpkgs-140774-workaround",
-        "rev": "a3c6d0622758e5d3da3d63100547f400ce6cb376",
+        "rev": "335c2052970106d8f09f6f7f522f29d6ccaa2416",
         "type": "github"
       },
       "original": {
@@ -361,11 +361,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1682879489,
-        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
+        "lastModified": 1677407201,
+        "narHash": "sha256-3blwdI9o1BAprkvlByHvtEm5HAIRn/XPjtcfiunpY7s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
+        "rev": "7f5639fa3b68054ca0b062866dc62b22c3f11505",
         "type": "github"
       },
       "original": {
@@ -442,11 +442,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1682960002,
-        "narHash": "sha256-5Zjh4pT3lAjFGN1gVrjqj1LLJHKCAlGdLD8raU7oEMc=",
+        "lastModified": 1681358109,
+        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8670e496ffd093b60e74e7fa53526aa5920d09eb",
+        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -119,11 +119,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1677714448,
-        "narHash": "sha256-Hq8qLs8xFu28aDjytfxjdC96bZ6pds21Yy09mSC156I=",
+        "lastModified": 1682984683,
+        "narHash": "sha256-fSMthG+tp60AHhNmaHc4StT3ltfHkQsJtN8GhfLWmtI=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "dc531e3a9ce757041e1afaff8ee932725ca60002",
+        "rev": "86684881e184f41aa322e653880e497b66429f3e",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
     },
     "flake-root": {
       "locked": {
-        "lastModified": 1680210152,
-        "narHash": "sha256-VgFdqsu2i2oUcId9n8BFlRRc4GJHFvrmprdamcSZR1o=",
+        "lastModified": 1680964220,
+        "narHash": "sha256-dIdTYcf+KW9a4pKHsEbddvLVSfR1yiAJynzg2x0nfWg=",
         "owner": "srid",
         "repo": "flake-root",
-        "rev": "6000244701c8ae8cf43263564095fd357d89c328",
+        "rev": "f1c0b93d05bdbea6c011136ba1a135c80c5b326c",
         "type": "github"
       },
       "original": {
@@ -224,11 +224,11 @@
     },
     "haskell-flake": {
       "locked": {
-        "lastModified": 1682614676,
-        "narHash": "sha256-Eu53z8fdtt8mfMRp+IskjclCT9LqvCViMOzvqO0Rz50=",
+        "lastModified": 1682714267,
+        "narHash": "sha256-DsGj9AIKqKcWQQOuwbFU77rkehaICzISHhH7aezZ6OQ=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "11ab35533afaf0cacc5f3ed8032cb2482cedf8fd",
+        "rev": "a904caac3e4638f84a28102762bf767dd1ae50c0",
         "type": "github"
       },
       "original": {
@@ -272,11 +272,11 @@
     },
     "mission-control": {
       "locked": {
-        "lastModified": 1680209746,
-        "narHash": "sha256-P8Q0mPdeo2SvKQUejvl7nOKO2ahIXb6aintYofCxcP8=",
+        "lastModified": 1682001320,
+        "narHash": "sha256-cXxEhjdJjWw1n8d14+PR8h/i0gLVLG2xq4kw5sJeuxg=",
         "owner": "Platonic-Systems",
         "repo": "mission-control",
-        "rev": "c1bd7344283d4006efb02cc660c5fd9befb73980",
+        "rev": "c2f3f0a8dce770c46bfa217270ee5592f3a5ebf5",
         "type": "github"
       },
       "original": {
@@ -329,11 +329,11 @@
     },
     "nixpkgs-140774-workaround": {
       "locked": {
-        "lastModified": 1678736468,
-        "narHash": "sha256-l5BdAeq9ymhUox0sTqeKibx9zkreWbIllwTvCamJLE8=",
+        "lastModified": 1681394207,
+        "narHash": "sha256-hk9RUPnChwKjCtm/YzixAak5wIzIw+b1avp7I3vg3dQ=",
         "owner": "srid",
         "repo": "nixpkgs-140774-workaround",
-        "rev": "335c2052970106d8f09f6f7f522f29d6ccaa2416",
+        "rev": "a3c6d0622758e5d3da3d63100547f400ce6cb376",
         "type": "github"
       },
       "original": {
@@ -361,11 +361,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1677407201,
-        "narHash": "sha256-3blwdI9o1BAprkvlByHvtEm5HAIRn/XPjtcfiunpY7s=",
+        "lastModified": 1682879489,
+        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7f5639fa3b68054ca0b062866dc62b22c3f11505",
+        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
         "type": "github"
       },
       "original": {
@@ -442,11 +442,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1681358109,
-        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
+        "lastModified": 1682960002,
+        "narHash": "sha256-5Zjh4pT3lAjFGN1gVrjqj1LLJHKCAlGdLD8raU7oEMc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
+        "rev": "8670e496ffd093b60e74e7fa53526aa5920d09eb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,8 @@
   outputs = inputs: {
     flakeModules = {
       default = import ./flake-module.nix { inherit inputs; };
-      ghc810 = ./nix/ghc810.nix;
+      # ghc810 = ./nix/ghc810.nix;
+      ghc927 = ./nix/ghc927.nix;
     };
   };
 }

--- a/nix/ghc927.nix
+++ b/nix/ghc927.nix
@@ -27,6 +27,13 @@ in
       autoWire = [ ];
 
       # Uses GHC-9.2.7 package set as base
+
+      # We use a versioned package-set instead of the more
+      # general `pkgs.haskellPackages` set in order to be
+      # more explicit about our intentions to use a
+      # specific GHC version and by extension the related
+      # packages versions that come with this snapshot
+
       basePackages = pkgs.haskell.packages.ghc927;
 
       source-overrides = {

--- a/nix/ghc927.nix
+++ b/nix/ghc927.nix
@@ -1,0 +1,46 @@
+# To use this package set in your `haskell-flake` projects, set the
+# `basePackages` option as follows:
+#
+# > basePackages = config.haskellProjects.ghc927.outputs.finalPackages;
+#
+{ self, lib, ... }:
+
+let
+  # A function that enables us to write `foo = [ dontCheck ]` instead of `foo =
+  # lib.pipe super.foo [ dontCheck ]` in haskell-flake's `overrides`.
+  compilePipe = f: self: super:
+    lib.mapAttrs
+      (name: value:
+        if lib.isList value then
+          lib.pipe super.${name} value
+        else
+          value
+      )
+      (f self super);
+in
+{
+  perSystem = { pkgs, lib, config, ... }: {
+    haskellProjects.ghc927 = {
+      # This is not a local project, so disable those options.
+      packages = { };
+      devShell.enable = false;
+      autoWire = [ ];
+
+      # Uses GHC-9.2.7 package set as base
+      basePackages = pkgs.haskell.packages.ghc927;
+
+      source-overrides = {
+        # Dependencies from Hackage
+
+      };
+
+      overrides = compilePipe (self: super: with pkgs.haskell.lib.compose; {
+        binary-parsers = [ unmarkBroken doJailbreak ];
+        mysql-haskell = [ doJailbreak ];
+        prometheus-proc = [ unmarkBroken doJailbreak ];
+        lrucaching = [ unmarkBroken doJailbreak ];
+        wire-streams = [doJailbreak];
+      });
+    };
+  };
+}

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -5,7 +5,7 @@ common:
   _file = __curPos.file;
   perSystem = { pkgs, lib, config, ... }: {
     haskellProjects.default = {
-      basePackages = config.haskellProjects.ghc810.outputs.finalPackages;
+      basePackages = config.haskellProjects.ghc927.outputs.finalPackages;
       devShell = {
         tools = hp: {
           inherit (pkgs.haskellPackages)


### PR DESCRIPTION
This PR is part of the broader GHC-9.2.7 upgrade work for the Mobility set of projects.

This PR updates the `common`  repo to use and provide GHC-9.2.7 compiler along with up-to-date packages, upgrading from the previous older and now-outdated 8.10 compiler and package-set.

Key Changes :-

1. Adds new GHC-9.2.7 package set, with minimal flag overrides needed to make it work.
2. Replaces the old `ghc810` _flakeModules_ attribute with the new `ghc927`  in `flake.nix` file.
3. Updates the `basePackages` in `nix/haskell.nix` file to now use the new `ghc927` package-set (`ghc810` -> `ghc927`).
4. In `flake-module.nix`, `ghc810.nix` is commented out and replaced with the new `ghc927.nix` file.
5. ~~Adds the updated `flake.lock` file after the above mentioned changes.~~ (f412f969b1652dd05f8f3df6f3cdf80e389897be)
6. Updates README file to inform of the 810 package set deprecation and subsequent addition of the 927 set.

Please let me know if there are other changes or corrections to be made here, be happy to.