### PR TITLE
haskell: Store hie-bios/cabal cache locally

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -4,7 +4,7 @@ common:
 {
   _file = __curPos.file;
   perSystem = { pkgs, lib, config, ... }: {
-    haskellProjects.default = {
+    haskellProjects.default = project: {
       basePackages = config.haskellProjects.ghc810.outputs.finalPackages;
       devShell = {
         tools = hp: {
@@ -23,6 +23,19 @@ common:
             hls-ormolu-plugin = null;
           };
         };
+
+        # For more reproducible dev shell env
+        # cf. https://github.com/srid/haskell-flake/issues/160
+        mkShellArgs.shellHook =
+          let
+            subdir = lib.strings.removePrefix
+              (builtins.toString self)
+              (builtins.toString project.config.projectRoot);
+          in
+          ''
+            export HIE_BIOS_CACHE_DIR=''${FLAKE_ROOT}/${subdir}/.hie-bios-cache
+            export CABAL_DIR=''${FLAKE_ROOT}/${subdir}/.cabal-dir
+          '';
       };
     };
   };


### PR DESCRIPTION
https://github.com/srid/haskell-flake/issues/160

To nuke the cache, all we have to do is `git clean -X`.