### PR TITLE
Upgrades "Ormolu" to a lot newer version "0.5.0.1" from older "0.1.4.1"

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -327,37 +327,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-140774-workaround": {
-      "locked": {
-        "lastModified": 1678736468,
-        "narHash": "sha256-l5BdAeq9ymhUox0sTqeKibx9zkreWbIllwTvCamJLE8=",
-        "owner": "srid",
-        "repo": "nixpkgs-140774-workaround",
-        "rev": "335c2052970106d8f09f6f7f522f29d6ccaa2416",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "nixpkgs-140774-workaround",
-        "type": "github"
-      }
-    },
-    "nixpkgs-21_11": {
-      "locked": {
-        "lastModified": 1659446231,
-        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-21.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
@@ -565,8 +534,6 @@
         "haskell-flake": "haskell-flake",
         "mission-control": "mission-control",
         "nixpkgs": "nixpkgs_3",
-        "nixpkgs-140774-workaround": "nixpkgs-140774-workaround",
-        "nixpkgs-21_11": "nixpkgs-21_11",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
         "process-compose-flake": "process-compose-flake",
         "treefmt-nix": "treefmt-nix"

--- a/flake.nix
+++ b/flake.nix
@@ -6,8 +6,6 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     haskell-flake.url = "github:srid/haskell-flake";
     flake-root.url = "github:srid/flake-root";
-    nixpkgs-21_11.url = "github:nixos/nixpkgs/nixos-21.11"; # Used for ormolu
-    nixpkgs-140774-workaround.url = "github:srid/nixpkgs-140774-workaround";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     cachix-push.url = "github:juspay/cachix-push";
 

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -14,14 +14,6 @@ common:
           inherit (hp)
             ghcid
             ;
-
-          # Disable ormolu in HLS, until we upgrade to the latest version, or
-          # switch to fourmolu
-          #
-          # See https://github.com/nammayatri/nammayatri/issues/649
-          haskell-language-server = (pkgs.haskell.lib.compose.disableCabalFlag "ormolu" hp.haskell-language-server).override {
-            hls-ormolu-plugin = null;
-          };
         };
       };
     };

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -16,11 +16,11 @@ common:
       programs.nixpkgs-fmt.enable = true;
       # FIXME: Disabled until https://github.com/nammayatri/nammayatri/issues/31
       # programs.hlint.enable = true;
+
+      # Ormolu Version is now at: 0.5.0.1
+      # TODO:// look into updating it to newest version 0.6.0.1
       programs.ormolu.enable = true;
 
-      programs.ormolu.package =
-        let pkgs-21_11 = common.inputs.nixpkgs-21_11.legacyPackages.${system};
-        in common.inputs.nixpkgs-140774-workaround.patch pkgs-21_11 pkgs-21_11.haskellPackages.ormolu;
       settings.formatter.ormolu = {
         options = [
           "--ghc-opt"


### PR DESCRIPTION
Solves nammayatri/nammayatri#737

### Key changes made in this PR include:

* Effectivly upgrades ormolu from "0.1.4.1" -> "0.5.0.1"

* Deletes code that disabled Ormolu in HLS in "nix/haskell.nix" file

* Removes the following, now redundant inputs from flake.nix file:
  - nixpkgs-21_11
  - nixpkgs-140774-workaround

  ^ They aren't required now that we use upstream "ormolu" version from nixpkgs-unstable.

* Updates flake.lock file with the above mentioned changes incorporated.