### PR TITLE
Mobility GHC927 rebased packet-set upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Nix-based project configuration shared between nammayatri repositories
 - The common flakeModule provides:
   - treefmt-based autoformatters: ormolu, hlint, dhall-format, nixpkgs-fmt
   - Common Haskell configuration
-    - GHC 8.10 package set (matching LTS 16.31 in part)
+    - ~~GHC 8.10 package set (matching LTS 16.31 in part)~~ (DEPRECATED, file and references kept for posterity only)
+    - GHC 9.2.7 package set
     - Avoid global tool caches (`no-global-cache.nix`)
   - `mission-control`
   - `process-compose-flake`

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -8,7 +8,8 @@ common:
     common.inputs.haskell-flake.flakeModule
     (import ./nix/treefmt.nix common)
     ./nix/haskell
-    ./nix/ghc810.nix
+    # ./nix/ghc810.nix
+    ./nix/ghc927.nix
     ./nix/pre-commit.nix
     ./nix/arion.nix
     common.inputs.cachix-push.flakeModule

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,8 @@
   outputs = inputs: {
     flakeModules = {
       default = import ./flake-module.nix { inherit inputs; };
-      ghc810 = ./nix/ghc810.nix;
+      # ghc810 = ./nix/ghc810.nix;
+      ghc927 = ./nix/ghc927.nix;
     };
 
     lib.mkFlake = args: mod:

--- a/nix/ghc927.nix
+++ b/nix/ghc927.nix
@@ -27,6 +27,13 @@ in
       autoWire = [ ];
 
       # Uses GHC-9.2.7 package set as base
+
+      # We use a versioned package-set instead of the more
+      # general `pkgs.haskellPackages` set in order to be
+      # more explicit about our intentions to use a
+      # specific GHC version and by extension the related
+      # packages versions that come with this snapshot
+
       basePackages = pkgs.haskell.packages.ghc927;
 
       source-overrides = {

--- a/nix/ghc927.nix
+++ b/nix/ghc927.nix
@@ -3,26 +3,13 @@
 #
 # > basePackages = config.haskellProjects.ghc927.outputs.finalPackages;
 #
-{ self, lib, ... }:
-
-let
-  # A function that enables us to write `foo = [ dontCheck ]` instead of `foo =
-  # lib.pipe super.foo [ dontCheck ]` in haskell-flake's `overrides`.
-  compilePipe = f: self: super:
-    lib.mapAttrs
-      (name: value:
-        if lib.isList value then
-          lib.pipe super.${name} value
-        else
-          value
-      )
-      (f self super);
-in
 {
   perSystem = { pkgs, lib, config, ... }: {
     haskellProjects.ghc927 = {
+      projectFlakeName = "nammayatri:common";
+
       # This is not a local project, so disable those options.
-      packages = { };
+      defaults.packages = {};
       devShell.enable = false;
       autoWire = [ ];
 
@@ -36,18 +23,31 @@ in
 
       basePackages = pkgs.haskell.packages.ghc927;
 
-      source-overrides = {
+      packages = {
         # Dependencies from Hackage
 
       };
 
-      overrides = compilePipe (self: super: with pkgs.haskell.lib.compose; {
-        binary-parsers = [ unmarkBroken doJailbreak ];
-        mysql-haskell = [ doJailbreak ];
-        prometheus-proc = [ unmarkBroken doJailbreak ];
-        lrucaching = [ unmarkBroken doJailbreak ];
-        wire-streams = [doJailbreak];
-      });
+      settings = {
+        binary-parsers = {
+          broken = false;
+          jailbreak = true;
+        };
+        mysql-haskell = {
+          jailbreak = true;
+        };
+        prometheus-proc = {
+          broken = false;
+          jailbreak = true;
+        };
+        lrucaching = {
+          broken = false;
+          jailbreak = true;
+        };
+        wire-streams = {
+          jailbreak = true;
+        };
+      };
     };
   };
 }

--- a/nix/ghc927.nix
+++ b/nix/ghc927.nix
@@ -1,0 +1,46 @@
+# To use this package set in your `haskell-flake` projects, set the
+# `basePackages` option as follows:
+#
+# > basePackages = config.haskellProjects.ghc927.outputs.finalPackages;
+#
+{ self, lib, ... }:
+
+let
+  # A function that enables us to write `foo = [ dontCheck ]` instead of `foo =
+  # lib.pipe super.foo [ dontCheck ]` in haskell-flake's `overrides`.
+  compilePipe = f: self: super:
+    lib.mapAttrs
+      (name: value:
+        if lib.isList value then
+          lib.pipe super.${name} value
+        else
+          value
+      )
+      (f self super);
+in
+{
+  perSystem = { pkgs, lib, config, ... }: {
+    haskellProjects.ghc927 = {
+      # This is not a local project, so disable those options.
+      packages = { };
+      devShell.enable = false;
+      autoWire = [ ];
+
+      # Uses GHC-9.2.7 package set as base
+      basePackages = pkgs.haskell.packages.ghc927;
+
+      source-overrides = {
+        # Dependencies from Hackage
+
+      };
+
+      overrides = compilePipe (self: super: with pkgs.haskell.lib.compose; {
+        binary-parsers = [ unmarkBroken doJailbreak ];
+        mysql-haskell = [ doJailbreak ];
+        prometheus-proc = [ unmarkBroken doJailbreak ];
+        lrucaching = [ unmarkBroken doJailbreak ];
+        wire-streams = [doJailbreak];
+      });
+    };
+  };
+}

--- a/nix/haskell/default.nix
+++ b/nix/haskell/default.nix
@@ -5,7 +5,7 @@
         ./no-global-cache.nix
         ./devtools.nix
       ];
-      basePackages = config.haskellProjects.ghc810.outputs.finalPackages;
+      basePackages = config.haskellProjects.ghc927.outputs.finalPackages;
     };
   };
 }


### PR DESCRIPTION
supersedes #6 

This PR contains GHC-9.2.7 package set updates (same as #5 , #8), rebased for updated haskell-flake changes, minus the ormolu changes in #10