### PR TITLE
Mobility GHC927 upgrade final

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Nix-based project configuration shared between nammayatri repositories
 - The common flakeModule provides:
   - treefmt-based autoformatters: ormolu, hlint, dhall-format, nixpkgs-fmt
   - Common Haskell configuration
-    - GHC 8.10 package set (matching LTS 16.31 in part)
+    - ~~GHC 8.10 package set (matching LTS 16.31 in part)~~ (DEPRECATED, file and references kept for posterity only)
+    - GHC 9.2.7 package set
     - Avoid global tool caches (`no-global-cache.nix`)
     - Common `package.yaml` (hpack) configuration
   - `mission-control`

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -8,7 +8,8 @@ common:
     common.inputs.haskell-flake.flakeModule
     (import ./nix/treefmt.nix common)
     ./nix/haskell
-    ./nix/ghc810.nix
+    # ./nix/ghc810.nix
+    ./nix/ghc927.nix
     ./nix/pre-commit.nix
     ./nix/arion.nix
     common.inputs.cachix-push.flakeModule

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -25,6 +25,13 @@ common:
     _module.args.pkgs = import inputs.nixpkgs {
       inherit system;
       config.allowUnfree = true;
+      # Note:-
+      # Temporarily allow nodejs14, just to advance with testing build purposes.
+      # DO NOT DEPLOY OR MERGE THIS, IT IS INSECURE!
+      config.permittedInsecurePackages = [
+        "nodejs-14.21.3"
+        "openssl-1.1.1w"
+      ];
       overlays = [
         (self: super: {
           hpack = super.callPackage ./nix/haskell/hpack { inherit (super) hpack; };

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -28,6 +28,9 @@ common:
       # Note:-
       # Temporarily allow nodejs14, just to advance with testing build purposes.
       # DO NOT DEPLOY OR MERGE THIS, IT IS INSECURE!
+      #
+      # UPDATE on Note:-
+      #   The Frontend team will take up the nodejs upgrade separately
       config.permittedInsecurePackages = [
         "nodejs-14.21.3"
         "openssl-1.1.1w"

--- a/flake.lock
+++ b/flake.lock
@@ -442,11 +442,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1681358109,
-        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
+        "lastModified": 1694032533,
+        "narHash": "sha256-I8cfCV/4JNJJ8KHOTxTU1EphKT8ARSb4s9pq99prYV0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
+        "rev": "efd23a1c9ae8c574e2ca923c2b2dc336797f4cc4",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -442,11 +442,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1694032533,
-        "narHash": "sha256-I8cfCV/4JNJJ8KHOTxTU1EphKT8ARSb4s9pq99prYV0=",
+        "lastModified": 1696261572,
+        "narHash": "sha256-s8TtSYJ1LBpuITXjbPLUPyxzAKw35LhETcajJjCS5f0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "efd23a1c9ae8c574e2ca923c2b2dc336797f4cc4",
+        "rev": "0c7ffbc66e6d78c50c38e717ec91a2a14e0622fb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,8 @@
   outputs = inputs: {
     flakeModules = {
       default = import ./flake-module.nix { inherit inputs; };
-      ghc810 = ./nix/ghc810.nix;
+      # ghc810 = ./nix/ghc810.nix;
+      ghc927 = ./nix/ghc927.nix;
     };
 
     lib.mkFlake = args: mod:

--- a/nix/ghc927.nix
+++ b/nix/ghc927.nix
@@ -27,6 +27,13 @@ in
       autoWire = [ ];
 
       # Uses GHC-9.2.7 package set as base
+
+      # We use a versioned package-set instead of the more
+      # general `pkgs.haskellPackages` set in order to be
+      # more explicit about our intentions to use a
+      # specific GHC version and by extension the related
+      # packages versions that come with this snapshot
+
       basePackages = pkgs.haskell.packages.ghc927;
 
       source-overrides = {

--- a/nix/ghc927.nix
+++ b/nix/ghc927.nix
@@ -3,26 +3,13 @@
 #
 # > basePackages = config.haskellProjects.ghc927.outputs.finalPackages;
 #
-{ self, lib, ... }:
-
-let
-  # A function that enables us to write `foo = [ dontCheck ]` instead of `foo =
-  # lib.pipe super.foo [ dontCheck ]` in haskell-flake's `overrides`.
-  compilePipe = f: self: super:
-    lib.mapAttrs
-      (name: value:
-        if lib.isList value then
-          lib.pipe super.${name} value
-        else
-          value
-      )
-      (f self super);
-in
 {
   perSystem = { pkgs, lib, config, ... }: {
     haskellProjects.ghc927 = {
+      projectFlakeName = "nammayatri:common";
+
       # This is not a local project, so disable those options.
-      packages = { };
+      defaults.packages = {};
       devShell.enable = false;
       autoWire = [ ];
 
@@ -36,18 +23,31 @@ in
 
       basePackages = pkgs.haskell.packages.ghc927;
 
-      source-overrides = {
+      packages = {
         # Dependencies from Hackage
 
       };
 
-      overrides = compilePipe (self: super: with pkgs.haskell.lib.compose; {
-        binary-parsers = [ unmarkBroken doJailbreak ];
-        mysql-haskell = [ doJailbreak ];
-        prometheus-proc = [ unmarkBroken doJailbreak ];
-        lrucaching = [ unmarkBroken doJailbreak ];
-        wire-streams = [doJailbreak];
-      });
+      settings = {
+        binary-parsers = {
+          broken = false;
+          jailbreak = true;
+        };
+        mysql-haskell = {
+          jailbreak = true;
+        };
+        prometheus-proc = {
+          broken = false;
+          jailbreak = true;
+        };
+        lrucaching = {
+          broken = false;
+          jailbreak = true;
+        };
+        wire-streams = {
+          jailbreak = true;
+        };
+      };
     };
   };
 }

--- a/nix/ghc927.nix
+++ b/nix/ghc927.nix
@@ -1,0 +1,46 @@
+# To use this package set in your `haskell-flake` projects, set the
+# `basePackages` option as follows:
+#
+# > basePackages = config.haskellProjects.ghc927.outputs.finalPackages;
+#
+{ self, lib, ... }:
+
+let
+  # A function that enables us to write `foo = [ dontCheck ]` instead of `foo =
+  # lib.pipe super.foo [ dontCheck ]` in haskell-flake's `overrides`.
+  compilePipe = f: self: super:
+    lib.mapAttrs
+      (name: value:
+        if lib.isList value then
+          lib.pipe super.${name} value
+        else
+          value
+      )
+      (f self super);
+in
+{
+  perSystem = { pkgs, lib, config, ... }: {
+    haskellProjects.ghc927 = {
+      # This is not a local project, so disable those options.
+      packages = { };
+      devShell.enable = false;
+      autoWire = [ ];
+
+      # Uses GHC-9.2.7 package set as base
+      basePackages = pkgs.haskell.packages.ghc927;
+
+      source-overrides = {
+        # Dependencies from Hackage
+
+      };
+
+      overrides = compilePipe (self: super: with pkgs.haskell.lib.compose; {
+        binary-parsers = [ unmarkBroken doJailbreak ];
+        mysql-haskell = [ doJailbreak ];
+        prometheus-proc = [ unmarkBroken doJailbreak ];
+        lrucaching = [ unmarkBroken doJailbreak ];
+        wire-streams = [doJailbreak];
+      });
+    };
+  };
+}

--- a/nix/ghc927.nix
+++ b/nix/ghc927.nix
@@ -47,6 +47,14 @@
         wire-streams = {
           jailbreak = true;
         };
+        servant-foreign = {
+          broken = false;
+          jailbreak = true;
+        };
+        openapi3 = {
+          broken = false;
+          check = false;
+        };
       };
     };
   };

--- a/nix/haskell/default.nix
+++ b/nix/haskell/default.nix
@@ -5,7 +5,7 @@
         ./no-global-cache.nix
         ./devtools.nix
       ];
-      basePackages = config.haskellProjects.ghc810.outputs.finalPackages;
+      basePackages = config.haskellProjects.ghc927.outputs.finalPackages;
       defaults.settings.default = { name, package, config, ... }:
         lib.optionalAttrs (package.local.toDefinedProject or false) {
           # Disabling haddock and profiling is mainly to speed up Nix builds.

--- a/nix/haskell/default.nix
+++ b/nix/haskell/default.nix
@@ -12,13 +12,7 @@
           haddock = lib.mkDefault false;
           # Avoid double-compilation.
           libraryProfiling = lib.mkDefault false;
-          separateBinOutput =
-            if package.cabal.executables == [ ]
-            then null
-            # The use of -fwhole-archive-hs-libs (see hpack/defaults.yaml)
-            # breaks builds on macOS (cyclic references between bin and out); this
-            # works around that.
-            else !pkgs.stdenv.isDarwin;
+          separateBinOutput = package.cabal.executables != [ ];
         };
     };
   };

--- a/nix/haskell/hpack/defaults.yaml
+++ b/nix/haskell/hpack/defaults.yaml
@@ -3,7 +3,3 @@
 
 # Workaround for segfault on macOS
 # https://github.com/NixOS/nixpkgs/issues/149692#issuecomment-1587564664
-when:
-  - condition: os(darwin)
-    ghc-options:
-      - -fwhole-archive-hs-libs


### PR DESCRIPTION
This PR contains all the changes required to upgrade to GHC 9.2.7

Changes include:- 

1. Now provides an updated GHC 9.2.7 package set.
2. ghc927 is now default and replaces the old ghc810 package set.
3. Old ghc810 flake-modules attribute is now replaced by ghc927.
4. Removes the whole `-fwhole-archive-hs-libs` business.
5. Updated flake.lock with `nixpkgs` to a more recent verison.
6. Includes exception to allow nodejs14 after nixpkgs upgrade for now.