### PR TITLE
fix(HLS): turn off fourmolu plugin for Haskell-Language-Server

### DIFF
--- a/nix/haskell/devtools.nix
+++ b/nix/haskell/devtools.nix
@@ -13,8 +13,12 @@
     # switch to fourmolu
     #
     # See https://github.com/nammayatri/nammayatri/issues/649
-    haskell-language-server = (pkgs.haskell.lib.compose.disableCabalFlag "ormolu" hp.haskell-language-server).override {
+      haskell-language-server = (
+        pkgs.haskell.lib.compose.disableCabalFlag "fourmolu"
+          (pkgs.haskell.lib.compose.disableCabalFlag "ormolu" hp.haskell-language-server)
+      ).override {
       hls-ormolu-plugin = null;
+      hls-fourmolu-plugin = null;
     };
   };
 }


### PR DESCRIPTION
turns off the `formolu` option and `hls-forumolu-plugin` from `haskell-language-server` because it was failing to build (segfaulting) on `aarch64-darwin` .

haskell-language-server version: `2.1.0.0 (GHC: 9.2.7)`