### PR TITLE
Update nixpkgs for newer HLS version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -442,11 +442,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1696261572,
-        "narHash": "sha256-s8TtSYJ1LBpuITXjbPLUPyxzAKw35LhETcajJjCS5f0=",
+        "lastModified": 1704161960,
+        "narHash": "sha256-QGua89Pmq+FBAro8NriTuoO/wNaUtugt29/qqA8zeeM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0c7ffbc66e6d78c50c38e717ec91a2a14e0622fb",
+        "rev": "63143ac2c9186be6d9da6035fa22620018c85932",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps nixpkgs input to newer to get the newer version of HLS

```
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/0c7ffbc66e6d78c50c38e717ec91a2a14e0622fb' (2023-10-02)
  → 'github:nixos/nixpkgs/63143ac2c9186be6d9da6035fa22620018c85932' (2024-01-02)
```
There've been reports of haskell-language-server (HLS) not working well-enough for around ~half the files in the main NY repo.
This nixpkgs update affords us to use a newer version of HLS available with nix.

This takes us from:- 

    haskell-language-server 2.1.0.0 (current) -> haskell-language-server 2.4.0.0 (new)

HLS is being updated all the time and newer versions often have cool fixes, perf improvements and improved platform support. Newer versions also tend to increasingly work in more scenarios.

This should help with the dev experience.

cc: @0utkarsh 