### PR TITLE
Update haskell-flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
     },
     "haskell-flake": {
       "locked": {
-        "lastModified": 1685469326,
-        "narHash": "sha256-esxJLsGexI/J6Fc32tJd2p3K5IOBZSCHgFvegjIpc+0=",
+        "lastModified": 1704968632,
+        "narHash": "sha256-QUxzfOGRyDXhCnIYLyLQ5dF3SXQiBjA/XcrKuZhi0iI=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "996f5c2cdc67285c4990df378976f9dbf26f8401",
+        "rev": "c9c28dc5c27cb23b032f76b4bd4adc1fa715bcdc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
• Updated input 'haskell-flake':
    'github:srid/haskell-flake/996f5c2cdc67285c4990df378976f9dbf26f8401' (2023-05-30)
  → 'github:srid/haskell-flake/c9c28dc5c27cb23b032f76b4bd4adc1fa715bcdc' (2024-01-11)
```

Testing in https://github.com/nammayatri/nammayatri/pull/5016