### PR TITLE
ghc810: set `projectRoot` and expose it in flake

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -8,7 +8,7 @@ common:
     common.inputs.haskell-flake.flakeModule
     (import ./nix/treefmt.nix common)
     ./nix/haskell
-    # ./nix/ghc810.nix
+    ./nix/ghc810.nix
     ./nix/ghc927.nix
     ./nix/pre-commit.nix
     ./nix/arion.nix

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -8,7 +8,6 @@ common:
     common.inputs.haskell-flake.flakeModule
     (import ./nix/treefmt.nix common)
     ./nix/haskell
-    ./nix/ghc810.nix
     ./nix/ghc927.nix
     ./nix/pre-commit.nix
     ./nix/arion.nix

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
   outputs = inputs: {
     flakeModules = {
       default = import ./flake-module.nix { inherit inputs; };
-      # ghc810 = ./nix/ghc810.nix;
+      ghc810 = ./nix/ghc810.nix;
       ghc927 = ./nix/ghc927.nix;
     };
 

--- a/nix/ghc810.nix
+++ b/nix/ghc810.nix
@@ -7,6 +7,7 @@
   perSystem = { pkgs, lib, config, ... }: {
     haskellProjects.ghc810 = {
       projectFlakeName = "nammayatri:common";
+      projectRoot = ../;
 
       # This is not a local project, so disable those options.
       defaults.packages = { };

--- a/nix/ghc810.nix
+++ b/nix/ghc810.nix
@@ -7,7 +7,7 @@
   perSystem = { pkgs, lib, config, ... }: {
     haskellProjects.ghc810 = {
       projectFlakeName = "nammayatri:common";
-      projectRoot = ../;
+      projectRoot = ../.;
 
       # This is not a local project, so disable those options.
       defaults.packages = { };


### PR DESCRIPTION
Needed to test euler-hs with (uncommented changes of) https://github.com/srid/haskell-flake/pull/231