### PR TITLE
Update haskell-flake, pre-commit-hooks-nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -71,21 +71,6 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "locked": {
         "lastModified": 1659877975,
         "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
@@ -99,7 +84,7 @@
         "type": "github"
       }
     },
-    "flake-utils_3": {
+    "flake-utils_2": {
       "inputs": {
         "systems": "systems"
       },
@@ -125,11 +110,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660459072,
-        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
         "type": "github"
       },
       "original": {
@@ -140,15 +125,16 @@
     },
     "haskell-flake": {
       "locked": {
-        "lastModified": 1714025946,
-        "narHash": "sha256-R2k/UG5XtyTtmezRs0HZZ9MlvhWXtkyHR+ngEAWrtZI=",
-        "owner": "srid",
+        "lastModified": 1733821413,
+        "narHash": "sha256-1/I+745OA5msBChRdqooY5lh64vQ9pLhYVDXumjob64=",
+        "owner": "rsrohitsingh682",
         "repo": "haskell-flake",
-        "rev": "2ee7904390ce78a81d0f66fcc98bf4c32d128d33",
+        "rev": "81599f78edabade801f9fa6a445c9ea23b8ba01c",
         "type": "github"
       },
       "original": {
-        "owner": "srid",
+        "owner": "rsrohitsingh682",
+        "ref": "cache-cabal2nix",
         "repo": "haskell-flake",
         "type": "github"
       }
@@ -245,32 +231,32 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1678872516,
-        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
+        "lastModified": 1730741070,
+        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
+        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1681303793,
-        "narHash": "sha256-JEdQHsYuCfRL2PICHlOiH/2ue3DwoxUX7DJ6zZxZXFk=",
+        "lastModified": 1730768919,
+        "narHash": "sha256-8AKquNnnSaJRXZxc5YmF/WfmxiHX6MMZZasRP6RRQkE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fe2ecaf706a5907b5e54d979fbde4924d84b65fc",
+        "rev": "a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -326,28 +312,28 @@
     "pre-commit-hooks-nix": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
         "gitignore": "gitignore",
         "nixpkgs": "nixpkgs_2",
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1682596858,
-        "narHash": "sha256-Hf9XVpqaGqe/4oDGr30W8HlsWvJXtMsEPHDqHZA6dDg=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "fb58866e20af98779017134319b5663b8215d912",
+        "lastModified": 1733744945,
+        "narHash": "sha256-IKEqpBW4mxRxVIu2EOJldp7gJYwxBN+yNZxoW0QhP2w=",
+        "owner": "rsrohitsingh682",
+        "repo": "git-hooks.nix",
+        "rev": "be16516ddd761e03509849c2d037925f826740cc",
         "type": "github"
       },
       "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
+        "owner": "rsrohitsingh682",
+        "ref": "cabal2nix",
+        "repo": "git-hooks.nix",
         "type": "github"
       }
     },
     "process-compose": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
@@ -400,7 +386,7 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,8 @@
     # Commonly useful flakes
     mission-control.url = "github:Platonic-Systems/mission-control";
     process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
-    pre-commit-hooks-nix.url = "github:cachix/pre-commit-hooks.nix";
+    pre-commit-hooks-nix.url = "github:rsrohitsingh682/git-hooks.nix/cabal2nix";
+
 
     # Packages not in nixpkgs; or out of date in nixpkgs.
     process-compose.url = "github:F1bonacc1/process-compose"; # Until 0.80.0+ is nixpkgs, to get us: https://github.com/F1bonacc1/process-compose/issues/125

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs-latest.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
     flake-parts.url = "github:hercules-ci/flake-parts";
-    haskell-flake.url = "github:srid/haskell-flake";
+    haskell-flake.url = "github:rsrohitsingh682/haskell-flake/cache-cabal2nix";
     systems.url = "github:nix-systems/default";
     flake-root.url = "github:srid/flake-root";
     nixpkgs-21_11.url = "github:nixos/nixpkgs/nixos-21.11"; # Used for ormolu

--- a/nix/pre-commit.nix
+++ b/nix/pre-commit.nix
@@ -1,14 +1,22 @@
 # https://pre-commit.com/ hooks defined in Nix
 # cf. https://github.com/cachix/pre-commit-hooks.nix
-{ ... }:
+{ inputs, ... }:
 
 {
-  perSystem = { pkgs, lib, ... }: {
+  perSystem = { pkgs, lib, system, config, ... }: {
     pre-commit = {
+      pkgs = inputs.common.inputs.nixpkgs-latest.legacyPackages.${system};
       check.enable = true;
       settings = {
         hooks = {
-          treefmt.enable = true;
+          treefmt = {
+            enable = true;
+            excludes = [ config.pre-commit.settings.hooks.cabal2nix.settings.output_filename ];
+          };
+          cabal2nix = {
+            enable = true;
+            settings.output_filename = "cabal.nix";
+          };
           nil.enable = lib.mkDefault true;
           hpack.enable = true;
           # FIXME: Disabled due to purity issues


### PR DESCRIPTION
1. Update pre-commit-hooks-nix to enable `cabal2nix` hook which will generate nix expressions from `.cabal` file
2. Update haskell-flake which utilises this `cabal2nix` generated nix expressions to avoid IFD less evaluation.